### PR TITLE
variables are considered unused if they are only deconstructed in function bindings

### DIFF
--- a/tests/NoUnusedVariablesTest.elm
+++ b/tests/NoUnusedVariablesTest.elm
@@ -615,6 +615,15 @@ a =
         Just (Bar.Baz range) ->
             []"""
                 |> Review.Test.expectNoErrors
+    , test "should not report unused import when a type is deconstructed in a function call" <|
+        \() ->
+            testRule """module SomeModule exposing (a)
+import Bar
+
+a (Bar.Baz range) =
+    []
+    """
+                |> Review.Test.expectNoErrors
     ]
 
 


### PR DESCRIPTION
I have a bunch of functions that deconstruct a single-constructor union type when accepting variables. `review-unused` doesn't currently consider these as uses, so the `--fix` removes the import and causes a failure!

This normally would have been an issue, but I realized I could just add the SSCCE directly in your test suite—hope that's OK!