### PR TITLE
main should not be reported as unused

### DIFF
--- a/tests/NoUnusedVariablesTest.elm
+++ b/tests/NoUnusedVariablesTest.elm
@@ -206,6 +206,13 @@ a = Html.Styled.Attributes.href"""
 
 a = Html.Styled.Attributes.href"""
                     ]
+    , test "should not report main as unused, even if it's not exposed" <|
+        \() ->
+            testRule """module SomeModule exposing (a)
+main = Html.text "hello, world"
+a = ()
+            """
+                |> Review.Test.expectNoErrors
     ]
 
 


### PR DESCRIPTION
`--fix` removed `main` from a file, which caused a CI failure! We fixed it locally by exposing `main`, but I thought I'd report it back as well.

Attached is the SSCCE—again, hope it's OK that this is a PR instead of an issue!