### PR TITLE
arguments destructured in function definitions in let/in blocks are not marked as used

### DIFF
--- a/tests/NoUnusedVariablesTest.elm
+++ b/tests/NoUnusedVariablesTest.elm
@@ -669,6 +669,19 @@ a (Bar.Baz range) =
     []
     """
                 |> Review.Test.expectNoErrors
+    , test "should not report unused imports when a type is deconstructed in a function call in a let" <|
+        \() ->
+            testRule """module SomeModule exposing (outer)
+import Bar
+
+outer arg =
+    let
+        inner (Bar.Baz range) =
+            []
+    in
+    inner arg
+    """
+                |> Review.Test.expectNoErrors
     ]
 
 


### PR DESCRIPTION
Hi! Thanks for the quick fixes today, just one more error to report (in 1.0.1.) The attached test case fails. I recognize this is not a super common case! In fact, across all of NoRedInk's code base it only happens once.