### PR TITLE
Fix possible stack overflow errors

### DIFF
--- a/src/NoUnused/Parameters.elm
+++ b/src/NoUnused/Parameters.elm
@@ -339,7 +339,7 @@ errorsForRecordValueList : PatternUse -> Range -> List (Node String) -> Context 
 errorsForRecordValueList use recordRange list context =
     let
         ( unused, used ) =
-            List.partition (\(Node _ value) -> Set.member value context) list
+            List.partition (isNodeInContext context) list
     in
     case unused of
         [] ->
@@ -380,6 +380,11 @@ errorsForRecordValueList use recordRange list context =
               ]
             , List.foldl forgetNode context unused
             )
+
+
+isNodeInContext : Context -> Node String -> Bool
+isNodeInContext context (Node _ value) =
+    Set.member value context
 
 
 listToMessage : String -> List String -> String

--- a/src/NoUnused/Parameters.elm
+++ b/src/NoUnused/Parameters.elm
@@ -198,13 +198,14 @@ removeDetails =
 
 
 andThen :
-    (Context -> ( List (Rule.Error {}), Context ))
+    (value -> Context -> ( List (Rule.Error {}), Context ))
+    -> value
     -> ( List (Rule.Error {}), Context )
     -> ( List (Rule.Error {}), Context )
-andThen function ( errors, context ) =
+andThen function value ( errors, context ) =
     let
         ( newErrors, newContext ) =
-            function context
+            function value context
     in
     ( newErrors ++ errors, newContext )
 
@@ -216,14 +217,7 @@ errorsForFunctionImplementation (Node _ { arguments }) context =
 
 errorsForLetDeclarationList : List (Node Expression.LetDeclaration) -> Context -> ( List (Rule.Error {}), Context )
 errorsForLetDeclarationList list context =
-    case list of
-        [] ->
-            ( [], context )
-
-        first :: rest ->
-            context
-                |> errorsForLetDeclaration first
-                |> andThen (errorsForLetDeclarationList rest)
+    List.foldl (andThen errorsForLetDeclaration) ( [], context ) list
 
 
 errorsForLetDeclaration : Node Expression.LetDeclaration -> Context -> ( List (Rule.Error {}), Context )
@@ -248,14 +242,7 @@ type PatternUse
 
 errorsForPatternList : PatternUse -> List (Node Pattern) -> Context -> ( List (Rule.Error {}), Context )
 errorsForPatternList use list context =
-    case list of
-        [] ->
-            ( [], context )
-
-        first :: rest ->
-            context
-                |> errorsForPattern use first
-                |> andThen (errorsForPatternList use rest)
+    List.foldl (andThen (errorsForPattern use)) ( [], context ) list
 
 
 errorsForPattern : PatternUse -> Node Pattern -> Context -> ( List (Rule.Error {}), Context )
@@ -295,7 +282,7 @@ errorsForPattern use (Node range pattern) context =
         Pattern.AsPattern inner name ->
             context
                 |> errorsForAsPattern use range inner name
-                |> andThen (errorsForPattern use inner)
+                |> andThen (errorsForPattern use) inner
 
         Pattern.ParenthesizedPattern inner ->
             errorsForPattern use inner context

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -309,7 +309,7 @@ errorsForRecordValueList : Range -> List (Node String) -> Context -> ( List (Rul
 errorsForRecordValueList recordRange list context =
     let
         ( unused, used ) =
-            List.partition (\(Node _ value) -> Set.member value context) list
+            List.partition (isNodeInContext context) list
     in
     case unused of
         [] ->
@@ -345,6 +345,11 @@ errorsForRecordValueList recordRange list context =
               ]
             , List.foldl forgetNode context unused
             )
+
+
+isNodeInContext : Context -> Node String -> Bool
+isNodeInContext context (Node _ value) =
+    Set.member value context
 
 
 listToMessage : String -> List String -> String

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -186,27 +186,21 @@ removeDetails =
 
 
 andThen :
-    (Context -> ( List (Rule.Error {}), Context ))
+    (value -> Context -> ( List (Rule.Error {}), Context ))
+    -> value
     -> ( List (Rule.Error {}), Context )
     -> ( List (Rule.Error {}), Context )
-andThen function ( errors, context ) =
+andThen function value ( errors, context ) =
     let
         ( newErrors, newContext ) =
-            function context
+            function value context
     in
     ( newErrors ++ errors, newContext )
 
 
 errorsForCaseList : List Expression.Case -> Context -> ( List (Rule.Error {}), Context )
 errorsForCaseList list context =
-    case list of
-        [] ->
-            ( [], context )
-
-        first :: rest ->
-            context
-                |> errorsForCase first
-                |> andThen (errorsForCaseList rest)
+    List.foldl (andThen errorsForCase) ( [], context ) list
 
 
 errorsForCase : Expression.Case -> Context -> ( List (Rule.Error {}), Context )
@@ -216,14 +210,7 @@ errorsForCase ( pattern, _ ) context =
 
 errorsForLetDeclarationList : List (Node Expression.LetDeclaration) -> Context -> ( List (Rule.Error {}), Context )
 errorsForLetDeclarationList list context =
-    case list of
-        [] ->
-            ( [], context )
-
-        first :: rest ->
-            context
-                |> errorsForLetDeclaration first
-                |> andThen (errorsForLetDeclarationList rest)
+    List.foldl (andThen errorsForLetDeclaration) ( [], context ) list
 
 
 errorsForLetDeclaration : Node Expression.LetDeclaration -> Context -> ( List (Rule.Error {}), Context )
@@ -243,14 +230,7 @@ type PatternUse
 
 errorsForPatternList : PatternUse -> List (Node Pattern) -> Context -> ( List (Rule.Error {}), Context )
 errorsForPatternList use list context =
-    case list of
-        [] ->
-            ( [], context )
-
-        first :: rest ->
-            context
-                |> errorsForPattern use first
-                |> andThen (errorsForPatternList use rest)
+    List.foldl (andThen (errorsForPattern use)) ( [], context ) list
 
 
 errorsForPattern : PatternUse -> Node Pattern -> Context -> ( List (Rule.Error {}), Context )
@@ -290,7 +270,7 @@ errorsForPattern use (Node range pattern) context =
         Pattern.AsPattern inner name ->
             context
                 |> errorsForAsPattern range inner name
-                |> andThen (errorsForPattern use inner)
+                |> andThen (errorsForPattern use) inner
 
         Pattern.ParenthesizedPattern inner ->
             errorsForPattern use inner context


### PR DESCRIPTION
- [x] Upgrade NameVisitor to v0.2.0
  - Fixes possible stack overflow error
  - Allows NameVisitor to work in Project Schema Rules
- [x] Remove recursion from NoUnused.Patterns
- [x] Remove recursion from NoUnused.Parameters